### PR TITLE
fix(new-project): configure turbopack root and remove external fonts

### DIFF
--- a/new-project/next.config.ts
+++ b/new-project/next.config.ts
@@ -1,7 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    // Explicitly define the project root so Next.js doesn't
+    // mistakenly treat the repository root as the workspace root
+    // when multiple lockfiles are present.
+    root: __dirname,
+  },
 };
 
 export default nextConfig;

--- a/new-project/src/app/layout.tsx
+++ b/new-project/src/app/layout.tsx
@@ -1,17 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import "./home.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -25,9 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
-      </body>
+      <body>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- configure turbopack root to avoid workspace warnings
- remove google font imports from layout to prevent module resolution errors

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68ac5b5a7248833197b325b2a7069d58