### PR TITLE
Center homepage layout

### DIFF
--- a/new-project/src/app/layout.tsx
+++ b/new-project/src/app/layout.tsx
@@ -14,7 +14,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <div id="root">{children}</div>
+      </body>
     </html>
   );
 }

--- a/new-project/src/styles/base.css
+++ b/new-project/src/styles/base.css
@@ -92,6 +92,7 @@ main {
 
 .index-main {
   max-width: 1440px;
+  margin: 0 auto;
 }
 
 ::placeholder {


### PR DESCRIPTION
## Summary
- ensure global `#root` wrapper exists so CSS centers content
- center `.index-main` container with `margin: 0 auto`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac7d77279083318fb175faa2895bfc