### PR TITLE
Add header and basic navigation pages to Next.js app

### DIFF
--- a/new-project/src/app/blog/page.tsx
+++ b/new-project/src/app/blog/page.tsx
@@ -1,0 +1,7 @@
+export default function BlogPage() {
+  return (
+    <main className="blog-page">
+      <h1>Blog</h1>
+    </main>
+  );
+}

--- a/new-project/src/app/community/page.tsx
+++ b/new-project/src/app/community/page.tsx
@@ -1,0 +1,7 @@
+export default function CommunityPage() {
+  return (
+    <main className="community-page">
+      <h1>Comunidad</h1>
+    </main>
+  );
+}

--- a/new-project/src/app/contact/page.tsx
+++ b/new-project/src/app/contact/page.tsx
@@ -1,0 +1,7 @@
+export default function ContactPage() {
+  return (
+    <main className="contact-page">
+      <h1>Contacto</h1>
+    </main>
+  );
+}

--- a/new-project/src/app/layout.tsx
+++ b/new-project/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import "./home.css";
+import "../styles/header.css";
+import Header from "../components/Header";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,6 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        <Header />
         <div id="root">{children}</div>
       </body>
     </html>

--- a/new-project/src/app/login/page.tsx
+++ b/new-project/src/app/login/page.tsx
@@ -1,0 +1,7 @@
+export default function LoginPage() {
+  return (
+    <main className="login-page">
+      <h1>Login</h1>
+    </main>
+  );
+}

--- a/new-project/src/app/profile/page.tsx
+++ b/new-project/src/app/profile/page.tsx
@@ -1,0 +1,7 @@
+export default function ProfilePage() {
+  return (
+    <main className="profile-page">
+      <h1>Perfil</h1>
+    </main>
+  );
+}

--- a/new-project/src/components/Header.tsx
+++ b/new-project/src/components/Header.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { FaHome, FaUsers, FaRegNewspaper, FaEnvelopeOpenText } from 'react-icons/fa';
+import '../styles/header.css';
+
+export default function Header() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const toggleMenu = () => setMenuOpen(prev => !prev);
+  const closeMenu = () => setMenuOpen(false);
+
+  return (
+    <header>
+      <div className="logo">
+        <Link href="/" onClick={closeMenu}>
+          <img src="/img/Logo_Nut_Header.svg" alt="Nut Logo" />
+        </Link>
+      </div>
+
+      <button
+        className={`hamburger-btn ${menuOpen ? 'active' : ''}`}
+        aria-label="Menú"
+        onClick={toggleMenu}
+      >
+        <span className="hamburger-line"></span>
+        <span className="hamburger-line"></span>
+        <span className="hamburger-line"></span>
+      </button>
+
+      <nav className={`nav-links ${menuOpen ? 'active' : ''}`}>
+        <Link href="/" onClick={closeMenu}>
+          <FaHome size={30} />
+          <span>Inicio</span>
+        </Link>
+        <Link href="/community" onClick={closeMenu}>
+          <FaUsers size={30} />
+          <span>Comunidad</span>
+        </Link>
+        <Link href="/blog" onClick={closeMenu}>
+          <FaRegNewspaper size={30} />
+          <span>Blog</span>
+        </Link>
+        <Link href="/contact" onClick={closeMenu}>
+          <FaEnvelopeOpenText size={30} />
+          <span>Contacto</span>
+        </Link>
+        <Link href="/login" className="login-button" onClick={closeMenu}>
+          <span className="button-text">Login</span>
+        </Link>
+      </nav>
+
+      <div className={`overlay ${menuOpen ? 'active' : ''}`} onClick={closeMenu}></div>
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Implement responsive header with navigation links
- Integrate header into app layout
- Add placeholder pages for community, blog, contact, login, and profile

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac93c2a2b083318808a0d3ecc3a289