### PR TITLE
feat: add server-side cache for product search

### DIFF
--- a/new-project/package-lock.json
+++ b/new-project/package-lock.json
@@ -8,6 +8,9 @@
       "name": "new-project",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.11.0",
+        "https-proxy-agent": "^7.0.6",
+        "ioredis": "^5.7.0",
         "next": "15.5.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -641,6 +644,12 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.0.tgz",
+      "integrity": "sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -1451,6 +1460,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1664,6 +1682,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1686,6 +1710,17 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1747,7 +1782,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -1821,6 +1855,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -1860,6 +1903,18 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/concat-map": {
@@ -1949,7 +2004,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2002,6 +2056,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2027,7 +2099,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -2115,7 +2186,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2124,7 +2194,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2160,7 +2229,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -2172,7 +2240,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -2742,6 +2809,26 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -2757,11 +2844,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2799,7 +2901,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -2823,7 +2924,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -2905,7 +3005,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2971,7 +3070,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2983,7 +3081,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -2998,12 +3095,24 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ignore": {
@@ -3052,6 +3161,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
+      "integrity": "sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.3.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3582,6 +3715,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3604,7 +3749,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3631,6 +3775,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3655,8 +3820,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -4035,6 +4199,12 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4106,6 +4276,27 @@
       "peerDependencies": {
         "react": ">=16.2.0",
         "react-dom": ">=16.2.0"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -4493,6 +4684,12 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",

--- a/new-project/package.json
+++ b/new-project/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "axios": "^1.11.0",
+    "https-proxy-agent": "^7.0.6",
+    "ioredis": "^5.7.0",
     "next": "15.5.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/new-project/src/app/api/SearchProducts/route.ts
+++ b/new-project/src/app/api/SearchProducts/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import type { Agent } from 'https';
+import { readCache, writeCache } from '@/lib/cache';
+
+const OFF_SEARCH_URL = process.env.OPENFOODFACTS_SEARCH_URL || 'https://world.openfoodfacts.org/cgi/search.pl';
+
+const normalize = (str: string) =>
+  str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .toLowerCase();
+
+export async function GET(req: NextRequest) {
+  const query = req.nextUrl.searchParams.get('query');
+  if (!query) {
+    return NextResponse.json({ success: false, message: 'Falta query' }, { status: 400 });
+  }
+
+  const startTime = Date.now();
+  const normalizedQuery = normalize(query);
+  const cacheKey = `search:${normalizedQuery}`;
+
+  const { data: cachedResults, source, freq } = await readCache(cacheKey);
+  if (cachedResults) {
+    const elapsedTime = Date.now() - startTime;
+    return NextResponse.json({ success: true, products: cachedResults, source, elapsedTime });
+  }
+
+  try {
+    const searchParams = {
+      search_terms: query,
+      page_size: 20,
+      fields: 'code,product_name,image_url',
+      search_simple: 1,
+      action: 'process',
+      json: 1,
+    };
+
+      const agentUrl = process.env.https_proxy || process.env.HTTPS_PROXY;
+      const options: { params: typeof searchParams; proxy?: boolean; httpsAgent?: Agent } = { params: searchParams };
+      if (agentUrl) {
+        options.proxy = false;
+        options.httpsAgent = new HttpsProxyAgent(agentUrl);
+      }
+
+      interface OffProductRaw { code: string; product_name: string; image_url: string }
+      interface OffResponse { products: OffProductRaw[] }
+      const result = await axios.get<OffResponse>(OFF_SEARCH_URL, options);
+
+      const productos = (result.data.products || [])
+        .filter((p) => p.product_name && p.image_url && p.code)
+        .map((p) => ({ code: p.code, name: p.product_name.trim(), image: p.image_url }));
+
+    const map = new Map<string, { code: string; name: string; images: string[] }>();
+    for (const prod of productos) {
+      if (!map.has(prod.code)) {
+        map.set(prod.code, { code: prod.code, name: prod.name, images: [prod.image] });
+      } else {
+        map.get(prod.code)!.images.push(prod.image);
+      }
+    }
+
+    const uniqueProducts = Array.from(map.values()).map((p) => ({
+      code: p.code,
+      name: p.name,
+      image: p.images.find(Boolean) || '',
+    }));
+
+    await writeCache(cacheKey, uniqueProducts, freq);
+    const elapsedTime = Date.now() - startTime;
+    return NextResponse.json({ success: true, products: uniqueProducts, source, elapsedTime });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('🔴 Error en API OpenFood:', message);
+    return NextResponse.json({ success: false, message: 'Error en API' }, { status: 500 });
+  }
+}

--- a/new-project/src/app/search/page.tsx
+++ b/new-project/src/app/search/page.tsx
@@ -1,0 +1,6 @@
+import SearchResults from '../../components/SearchResults';
+
+export default function SearchPage() {
+  return <SearchResults />;
+}
+

--- a/new-project/src/components/AlertPopup.tsx
+++ b/new-project/src/components/AlertPopup.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import ReactDOM from 'react-dom';
+
+interface AlertPopupProps {
+  message: string;
+  onClose: () => void;
+}
+
+export default function AlertPopup({ message, onClose }: AlertPopupProps) {
+  if (typeof document === 'undefined') return null;
+
+  return ReactDOM.createPortal(
+    <div className="alert-popup-container" onClick={onClose}>
+      <div className="alert-popup-content" onClick={(e) => e.stopPropagation()}>
+        <p>{message}</p>
+        <button className="alert-popup-close" onClick={onClose}>
+          Cerrar
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+

--- a/new-project/src/components/LazyImage.tsx
+++ b/new-project/src/components/LazyImage.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useState } from 'react';
+
+interface LazyImageProps {
+  src: string;
+  alt: string;
+  className?: string;
+}
+
+/* eslint-disable @next/next/no-img-element */
+export default function LazyImage({ src, alt, className }: LazyImageProps) {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <div className={`lazy-image-wrapper ${className ?? ''}`}>
+      {!loaded && <div className="image-skeleton" />}
+      <img
+        src={src}
+        alt={alt}
+        onLoad={() => setLoaded(true)}
+        style={{ display: loaded ? 'block' : 'none' }}
+      />
+    </div>
+  );
+}
+

--- a/new-project/src/components/SearchResults.tsx
+++ b/new-project/src/components/SearchResults.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import LazyImage from './LazyImage';
+import AlertPopup from './AlertPopup';
+
+interface Product {
+  code: string;
+  name: string;
+  image: string;
+}
+
+export default function SearchResults() {
+  const params = useSearchParams();
+  const query = params.get('query') ?? '';
+  const [loading, setLoading] = useState(true);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [warning, setWarning] = useState('');
+  const [alertMessage, setAlertMessage] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!query) return;
+    setLoading(true);
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || '';
+    const start = performance.now();
+    const isDev = process.env.NODE_ENV !== 'production' || localStorage.getItem('devMode') === 'true';
+    fetch(`${apiBase}/api/SearchProducts?query=${encodeURIComponent(query)}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.success) {
+          setProducts(data.products);
+          const elapsed = (performance.now() - start).toFixed(2);
+          const source = data.source === 'cache' ? 'la cache' : 'OpenFoodFacts';
+          if (isDev) {
+            setAlertMessage(`Resultados obtenidos de ${source} en ${elapsed} ms`);
+          }
+        } else {
+          setProducts([]);
+        }
+      })
+      .catch(() => setProducts([]))
+      .finally(() => setLoading(false));
+  }, [query]);
+
+  const handleClick = (product: Product) => {
+    if (selectionMode) {
+      setSelected((prev) => {
+        if (prev.includes(product.code)) return prev.filter((c) => c !== product.code);
+        if (prev.length >= 10) {
+          setWarning('Solo puedes comparar hasta 10 productos');
+          setTimeout(() => setWarning(''), 2000);
+          return prev;
+        }
+        return [...prev, product.code];
+      });
+    } else {
+      router.push(`/producto?code=${encodeURIComponent(product.code)}`);
+    }
+  };
+
+  const toggleSelection = () => {
+    if (selectionMode) setSelected([]);
+    setSelectionMode(!selectionMode);
+  };
+
+  const handleCompare = () => {
+    if (selected.length < 2) return;
+    const codes = selected.map((c) => encodeURIComponent(c)).join(',');
+    router.push(`/compare?codes=${codes}`);
+  };
+
+  const skeletons = Array.from({ length: 6 });
+
+  return (
+    <div className="search-results-page">
+      <header className="results-header">
+        <h2>Resultados para &quot;{query}&quot;</h2>
+        <button className="selection-toggle" onClick={toggleSelection}>
+          {selectionMode ? 'Cancelar' : 'Seleccionar'}
+        </button>
+      </header>
+
+      {loading ? (
+        <div className="cards-container">
+          {skeletons.map((_, i) => (
+            <div key={i} className="product-card">
+              <div className="lazy-image-wrapper">
+                <div className="image-skeleton" />
+              </div>
+              <div className="text-skeleton" />
+            </div>
+          ))}
+        </div>
+      ) : products.length === 0 ? (
+        <p className="no-results">No se encontraron productos.</p>
+      ) : (
+        <div className="cards-container">
+          {products.map((p) => {
+            const isSelected = selected.includes(p.code);
+            return (
+              <div
+                key={p.code}
+                className={`product-card${isSelected ? ' selected' : ''}`}
+                onClick={() => handleClick(p)}
+              >
+                <LazyImage src={p.image} alt={p.name} className="card-image" />
+                <h3 className="card-title">{p.name}</h3>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {selectionMode && (
+        <>
+          {warning && <div className="selection-warning">{warning}</div>}
+          <div className="compare-bar">
+            <button
+              className="compare-button"
+              disabled={selected.length < 2}
+              onClick={handleCompare}
+            >
+              Comparar ({selected.length})
+            </button>
+          </div>
+        </>
+      )}
+      {alertMessage && (
+        <AlertPopup message={alertMessage} onClose={() => setAlertMessage('')} />
+      )}
+    </div>
+  );
+}
+

--- a/new-project/src/lib/cache.ts
+++ b/new-project/src/lib/cache.ts
@@ -1,0 +1,38 @@
+import redis from './redis';
+
+const CACHE_THRESHOLD = parseInt(process.env.CACHE_THRESHOLD || '3', 10);
+const CACHE_TTL = 15778800; // 24 hours
+
+export async function readCache(key: string) {
+  if (!redis) {
+    return { data: null, source: 'openfoodfacts', freq: 0 } as const;
+  }
+  const freqKey = `freq:${key}`;
+  try {
+    const freq = await redis.incr(freqKey);
+    if (freq === 1) await redis.expire(freqKey, CACHE_TTL);
+    console.log('📦 Revisando cache para', key);
+    const cached = await redis.get(key);
+    if (cached) {
+      console.log('✅ Cache hit para', key);
+      return { data: JSON.parse(cached), source: 'cache', freq } as const;
+    }
+    console.log('❌ Cache miss para', key);
+    return { data: null, source: 'openfoodfacts', freq } as const;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('Redis read error:', message);
+    return { data: null, source: 'openfoodfacts', freq: 0 } as const;
+  }
+}
+
+export async function writeCache(key: string, value: unknown, freq: number) {
+  if (!redis || freq < CACHE_THRESHOLD) return;
+  try {
+    console.log('💾 Guardando en cache para', key);
+    await redis.setex(key, CACHE_TTL, JSON.stringify(value));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('Redis write error:', message);
+  }
+}

--- a/new-project/src/lib/redis.ts
+++ b/new-project/src/lib/redis.ts
@@ -1,0 +1,21 @@
+import Redis from 'ioredis';
+
+let redis: Redis | undefined;
+let redisUrl = process.env.REDIS_URL || process.env.UPSTASH_REDIS_URL;
+
+if (!redisUrl && process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) {
+  const url = new URL(process.env.UPSTASH_REDIS_REST_URL.replace(/^https?:\/\//, 'rediss://'));
+  url.username = 'default';
+  url.password = process.env.UPSTASH_REST_TOKEN;
+  redisUrl = url.toString();
+}
+
+if (redisUrl) {
+  redis = new Redis(redisUrl);
+  redis.on('connect', () => console.log('✅ Redis conectado'));
+  redis.on('error', (err) => console.error('Redis connection error:', err.message));
+} else {
+  console.log('⚠️ REDIS_URL no configurado, cache deshabilitado');
+}
+
+export default redis;


### PR DESCRIPTION
## Summary
- wire product search page to internal API
- add Redis cache utilities and dependencies
- expose `/api/SearchProducts` with cached OpenFoodFacts lookup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac95444654833180b3b278945709d9