### PR TITLE
Fix product search dependencies and cache

### DIFF
--- a/new-project/src/app/api/SearchProducts/route.ts
+++ b/new-project/src/app/api/SearchProducts/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios from 'axios';
+import axios, { type AxiosRequestConfig } from 'axios';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import type { Agent } from 'https';
 import { readCache, writeCache } from '@/lib/cache';
@@ -40,10 +40,10 @@ export async function GET(req: NextRequest) {
     };
 
       const agentUrl = process.env.https_proxy || process.env.HTTPS_PROXY;
-      const options: { params: typeof searchParams; proxy?: boolean; httpsAgent?: Agent } = { params: searchParams };
+      const options: AxiosRequestConfig = { params: searchParams };
       if (agentUrl) {
         options.proxy = false;
-        options.httpsAgent = new HttpsProxyAgent(agentUrl);
+        options.httpsAgent = new HttpsProxyAgent(agentUrl) as Agent;
       }
 
       interface OffProductRaw { code: string; product_name: string; image_url: string }

--- a/new-project/src/app/search/page.tsx
+++ b/new-project/src/app/search/page.tsx
@@ -1,6 +1,12 @@
-import SearchResults from '../../components/SearchResults';
+import { Suspense } from 'react';
+import SearchResults from '@/components/SearchResults';
+import Loader from '@/components/Loader';
 
 export default function SearchPage() {
-  return <SearchResults />;
+  return (
+    <Suspense fallback={<Loader />}>
+      <SearchResults />
+    </Suspense>
+  );
 }
 

--- a/new-project/src/lib/cache.ts
+++ b/new-project/src/lib/cache.ts
@@ -1,7 +1,7 @@
 import redis from './redis';
 
 const CACHE_THRESHOLD = parseInt(process.env.CACHE_THRESHOLD || '3', 10);
-const CACHE_TTL = 15778800; // 24 hours
+const CACHE_TTL = 86400; // 24 hours
 
 export async function readCache(key: string) {
   if (!redis) {

--- a/new-project/src/lib/redis.ts
+++ b/new-project/src/lib/redis.ts
@@ -4,9 +4,11 @@ let redis: Redis | undefined;
 let redisUrl = process.env.REDIS_URL || process.env.UPSTASH_REDIS_URL;
 
 if (!redisUrl && process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) {
-  const url = new URL(process.env.UPSTASH_REDIS_REST_URL.replace(/^https?:\/\//, 'rediss://'));
+  const url = new URL(
+    process.env.UPSTASH_REDIS_REST_URL.replace(/^https?:\/\//, 'rediss://')
+  );
   url.username = 'default';
-  url.password = process.env.UPSTASH_REST_TOKEN;
+  url.password = process.env.UPSTASH_REDIS_REST_TOKEN;
   redisUrl = url.toString();
 }
 


### PR DESCRIPTION
## Summary
- ensure axios requests compile with proper proxy handling
- correct cache TTL and Upstash token variable
- wrap search page in Suspense to support useSearchParams

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac9847b15c8331a7bf60d0da00e9bf