### PR TITLE
feat: add blog page

### DIFF
--- a/new-project/src/app/blog/page.tsx
+++ b/new-project/src/app/blog/page.tsx
@@ -1,7 +1,5 @@
-export default function BlogPage() {
-  return (
-    <main className="blog-page">
-      <h1>Blog</h1>
-    </main>
-  );
+import BlogPage from '@/components/BlogPage';
+
+export default function Blog() {
+  return <BlogPage />;
 }

--- a/new-project/src/components/BlogCard.tsx
+++ b/new-project/src/components/BlogCard.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { BlogPost } from '@/types';
+
+interface BlogCardProps {
+  post: BlogPost;
+  onClick: (post: BlogPost) => void;
+}
+
+export default function BlogCard({ post, onClick }: BlogCardProps) {
+  return (
+    <div className="nutrition-card" onClick={() => onClick(post)}>
+      <img
+        src={`/img/${post.imagen_url}`}
+        alt="Imagen del post"
+        className="community-card-image"
+      />
+      <h3 className="community-card-text">{post.titulo_post}</h3>
+    </div>
+  );
+}

--- a/new-project/src/components/BlogPage.tsx
+++ b/new-project/src/components/BlogPage.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Loader from './Loader';
+import BlogCard from './BlogCard';
+import BlogPopup from './BlogPopup';
+import { FiSearch } from 'react-icons/fi';
+import { BlogPost } from '@/types';
+
+export default function BlogPage() {
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+  const [popupPost, setPopupPost] = useState<BlogPost | null>(null);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      setLoading(true);
+      try {
+        const apiBase = process.env.NEXT_PUBLIC_API_URL || '';
+        const res = await fetch(`${apiBase}/api/blog`);
+        const data = await res.json();
+        setPosts(data);
+      } catch (err) {
+        console.error('Error al obtener posts del blog:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPosts();
+  }, []);
+
+  const handleSearch = (
+    e: React.KeyboardEvent<HTMLInputElement> | { key: string }
+  ) => {
+    if (e.key === 'Enter') {
+      const match = posts.find((post) =>
+        post.titulo_post.toLowerCase().includes(search.toLowerCase())
+      );
+      if (!match) alert('No se encontró ninguna tarjeta con ese nombre.');
+    }
+  };
+
+  const handleCardClick = (post: BlogPost) => {
+    setPopupPost(post);
+  };
+
+  const handleClosePopup = () => {
+    setPopupPost(null);
+  };
+
+  return (
+    <>
+      {/* HERO CON BUSCADOR */}
+      <section className="page" style={{ width: '90%' }}>
+        <div className="inner">
+          <div className="evaluation-content">
+            <h1>¿QUÉ QUERÉS APRENDER HOY?</h1>
+            <p>
+              Descubrí herramientas prácticas, consejos útiles y perspectivas actuales para transformar tu relación con la comida.
+            </p>
+            <div className="search-bar">
+              <button
+                className="search-button search-icon-button"
+                onClick={() => handleSearch({ key: 'Enter' })}
+              >
+                <FiSearch size={20} />
+              </button>
+              <input
+                type="text"
+                placeholder="Ej: Alimentación intuitiva"
+                className="search-input"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                onKeyDown={handleSearch}
+              />
+            </div>
+            <div className="search-hint">Presioná Enter o la lupa para buscar</div>
+          </div>
+        </div>
+      </section>
+
+      {/* LISTADO DE ARTÍCULOS */}
+      <section
+        className="sec-nutrition-lifestyle"
+        style={{ display: popupPost ? 'none' : 'block' }}
+      >
+        {loading ? (
+          <div className="loader">
+            <Loader />
+          </div>
+        ) : (
+          <div className="nutrition-lifestyle-inner">
+            <h3>Nutrición y Estilo de Vida</h3>
+            <p>
+              Explorá artículos cuidadosamente seleccionados sobre bienestar integral, alimentación consciente y hábitos saludables. Inspirate para hacer cambios positivos y sostenibles.
+            </p>
+            <div className="cards-row" id="cardsContainer">
+              {posts.map((post, idx) => (
+                <BlogCard key={idx} post={post} onClick={handleCardClick} />
+              ))}
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* POPUP DE ARTÍCULO */}
+      {popupPost && <BlogPopup post={popupPost} onClose={handleClosePopup} />}
+    </>
+  );
+}

--- a/new-project/src/components/BlogPopup.tsx
+++ b/new-project/src/components/BlogPopup.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { FaTimes } from 'react-icons/fa';
+import { BlogPost } from '@/types';
+
+interface BlogPopupProps {
+  post: BlogPost;
+  onClose: () => void;
+}
+
+export default function BlogPopup({ post, onClose }: BlogPopupProps) {
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  if (!post) return null;
+
+  const handleContainerClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if ((e.target as HTMLElement).classList.contains('blog-popup-container')) onClose();
+  };
+
+  return createPortal(
+    <div className="blog-popup-container" role="dialog" aria-modal="true" onClick={handleContainerClick}>
+      <div className="blog-popup-content" onClick={(e) => e.stopPropagation()}>
+        <button className="close-btn-popup" onClick={onClose} aria-label="Cerrar">
+          <FaTimes />
+        </button>
+        <img src={`/img/${post.imagen_url}`} alt="" className="blog-popup-image" />
+        <h1 id="blog-popup-title">{post.titulo_post}</h1>
+        <h3>Escrito por todo el equipo de Nut</h3>
+        <hr />
+        <span>{post.fecha_creacion}</span>
+        <p>{post.contenido_post}</p>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/new-project/src/types.ts
+++ b/new-project/src/types.ts
@@ -1,0 +1,6 @@
+export interface BlogPost {
+  titulo_post: string;
+  imagen_url: string;
+  fecha_creacion: string;
+  contenido_post: string;
+}


### PR DESCRIPTION
## Summary
- implement client blog page that loads posts from API and supports search
- add blog card and popup components for displaying and reading articles
- define shared blog post type

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac9ce4e5bc8331be0cc3a3fc7ea947