### PR TITLE
fix header login state with Clerk session

### DIFF
--- a/new-project/src/components/Header.tsx
+++ b/new-project/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useState } from 'react';
 import { FaHome, FaUsers, FaRegNewspaper, FaEnvelopeOpenText } from 'react-icons/fa';
+import { SignedIn, SignedOut, UserButton } from '@clerk/nextjs';
 import '../styles/header.css';
 
 export default function Header() {
@@ -46,9 +47,14 @@ export default function Header() {
           <FaEnvelopeOpenText size={30} />
           <span>Contacto</span>
         </Link>
-        <Link href="/login" className="login-button" onClick={closeMenu}>
-          <span className="button-text">Login</span>
-        </Link>
+        <SignedOut>
+          <Link href="/login" className="login-button" onClick={closeMenu}>
+            <span className="button-text">Login</span>
+          </Link>
+        </SignedOut>
+        <SignedIn>
+          <UserButton afterSignOutUrl="/" />
+        </SignedIn>
       </nav>
 
       <div className={`overlay ${menuOpen ? 'active' : ''}`} onClick={closeMenu}></div>


### PR DESCRIPTION
## Summary
- show Clerk UserButton when signed in and hide login link
- wire up SignedIn/SignedOut to keep header state in sync with session

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run lint` (warnings: Using `<img>` could result in slower LCP and higher bandwidth)


------
https://chatgpt.com/codex/tasks/task_e_68aca2394d348331b6b60686319e0b40