### PR TITLE
Implement posts API routes in Next.js project

### DIFF
--- a/new-project/src/app/api/darDislike/route.ts
+++ b/new-project/src/app/api/darDislike/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabaseClient';
+
+export async function POST(req: Request) {
+  const { idPost } = await req.json();
+
+  const { data, error } = await supabase
+    .from('posts')
+    .select('dislikes')
+    .eq('id_post', idPost)
+    .single();
+
+  if (error) {
+    return NextResponse.json({ success: false, message: error.message }, { status: 500 });
+  }
+
+  const dislikes = (data?.dislikes ?? 0) + 1;
+  const { error: updateError } = await supabase
+    .from('posts')
+    .update({ dislikes })
+    .eq('id_post', idPost);
+
+  if (updateError) {
+    return NextResponse.json({ success: false, message: updateError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/new-project/src/app/api/darLike/route.ts
+++ b/new-project/src/app/api/darLike/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabaseClient';
+
+export async function POST(req: Request) {
+  const { idPost } = await req.json();
+
+  const { data, error } = await supabase
+    .from('posts')
+    .select('likes')
+    .eq('id_post', idPost)
+    .single();
+
+  if (error) {
+    return NextResponse.json({ success: false, message: error.message }, { status: 500 });
+  }
+
+  const likes = (data?.likes ?? 0) + 1;
+  const { error: updateError } = await supabase
+    .from('posts')
+    .update({ likes })
+    .eq('id_post', idPost);
+
+  if (updateError) {
+    return NextResponse.json({ success: false, message: updateError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/new-project/src/app/api/obtenerPosts/route.ts
+++ b/new-project/src/app/api/obtenerPosts/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabaseClient';
+
+export async function GET() {
+  const { data, error } = await supabase
+    .from('posts')
+    .select('id_post, contenido_post, fecha_creacion, imagen_url, likes, dislikes')
+    .order('fecha_creacion', { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ success: false, message: error.message }, { status: 500 });
+  }
+
+  const posts = (data ?? []).map(post => ({
+    ...post,
+    liked: false,
+    disliked: false,
+  }));
+
+  return NextResponse.json({ success: true, posts });
+}

--- a/new-project/src/app/api/publicarPost/route.ts
+++ b/new-project/src/app/api/publicarPost/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabaseClient';
+
+export async function POST(req: Request) {
+  const { contenidoPost, imagenUrl } = await req.json();
+
+  const { error } = await supabase
+    .from('posts')
+    .insert({
+      contenido_post: contenidoPost,
+      imagen_url: imagenUrl,
+    });
+
+  if (error) {
+    return NextResponse.json({ success: false, message: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/new-project/src/app/community/page.tsx
+++ b/new-project/src/app/community/page.tsx
@@ -31,12 +31,10 @@ export default function CommunityPage() {
   const [loading, setLoading] = useState(true);
   const router = useRouter();
 
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
-
   const fetchPosts = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await fetch(`${apiUrl}/api/obtenerPosts`, { credentials: 'include' });
+      const res = await fetch('/api/obtenerPosts', { credentials: 'include' });
       const data = await res.json();
       if (data.success) {
         const mapped: Post[] = data.posts.map((post: ApiPost) => ({
@@ -56,17 +54,17 @@ export default function CommunityPage() {
     } finally {
       setLoading(false);
     }
-  }, [apiUrl]);
+  }, []);
 
   const checkAuth = useCallback(async () => {
     try {
-      const res = await fetch(`${apiUrl}/api/auth`, { credentials: 'include' });
+      const res = await fetch('/api/auth', { credentials: 'include' });
       const data = await res.json();
       setAuth(data);
     } catch (err) {
       console.error('Error al verificar sesión:', err);
     }
-  }, [apiUrl]);
+  }, []);
 
   useEffect(() => {
     fetchPosts();
@@ -95,7 +93,7 @@ export default function CommunityPage() {
       })
     );
     try {
-      await fetch(`${apiUrl}/api/darLike`, {
+      await fetch('/api/darLike', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
@@ -129,7 +127,7 @@ export default function CommunityPage() {
       })
     );
     try {
-      await fetch(`${apiUrl}/api/darDislike`, {
+      await fetch('/api/darDislike', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
@@ -170,7 +168,7 @@ export default function CommunityPage() {
         }
       }
 
-      await fetch(`${apiUrl}/api/publicarPost`, {
+      await fetch('/api/publicarPost', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- remove external API base URL configuration
- add Supabase-backed API routes for posts (fetch, like, dislike, publish)
- use internal API endpoints in community page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca20358e8833182b8d066b0426fe4