### PR TITLE
Fix community posts API table name

### DIFF
--- a/new-project/src/app/api/darDislike/route.ts
+++ b/new-project/src/app/api/darDislike/route.ts
@@ -4,8 +4,9 @@ import { supabase } from '@/lib/supabaseClient';
 export async function POST(req: Request) {
   const { idPost } = await req.json();
 
+  // The Posts table uses an uppercase name in the database.
   const { data, error } = await supabase
-    .from('posts')
+    .from('Posts')
     .select('dislikes')
     .eq('id_post', idPost)
     .single();
@@ -16,7 +17,7 @@ export async function POST(req: Request) {
 
   const dislikes = (data?.dislikes ?? 0) + 1;
   const { error: updateError } = await supabase
-    .from('posts')
+    .from('Posts')
     .update({ dislikes })
     .eq('id_post', idPost);
 

--- a/new-project/src/app/api/darLike/route.ts
+++ b/new-project/src/app/api/darLike/route.ts
@@ -4,8 +4,9 @@ import { supabase } from '@/lib/supabaseClient';
 export async function POST(req: Request) {
   const { idPost } = await req.json();
 
+  // The Posts table uses an uppercase name in the database.
   const { data, error } = await supabase
-    .from('posts')
+    .from('Posts')
     .select('likes')
     .eq('id_post', idPost)
     .single();
@@ -16,7 +17,7 @@ export async function POST(req: Request) {
 
   const likes = (data?.likes ?? 0) + 1;
   const { error: updateError } = await supabase
-    .from('posts')
+    .from('Posts')
     .update({ likes })
     .eq('id_post', idPost);
 

--- a/new-project/src/app/api/obtenerPosts/route.ts
+++ b/new-project/src/app/api/obtenerPosts/route.ts
@@ -2,8 +2,10 @@ import { NextResponse } from 'next/server';
 import { supabase } from '@/lib/supabaseClient';
 
 export async function GET() {
+  // The table was created with an uppercase name in PostgreSQL, so we
+  // need to reference it exactly as "Posts" when using Supabase.
   const { data, error } = await supabase
-    .from('posts')
+    .from('Posts')
     .select('id_post, contenido_post, fecha_creacion, imagen_url, likes, dislikes')
     .order('fecha_creacion', { ascending: false });
 

--- a/new-project/src/app/api/publicarPost/route.ts
+++ b/new-project/src/app/api/publicarPost/route.ts
@@ -4,8 +4,9 @@ import { supabase } from '@/lib/supabaseClient';
 export async function POST(req: Request) {
   const { contenidoPost, imagenUrl } = await req.json();
 
+  // The Posts table uses an uppercase name in the database.
   const { error } = await supabase
-    .from('posts')
+    .from('Posts')
     .insert({
       contenido_post: contenidoPost,
       imagen_url: imagenUrl,


### PR DESCRIPTION
## Summary
- reference correct `Posts` table in community API routes to avoid 500 errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca53c6f2c8331b22f131f99111a85