### PR TITLE
feat: add blog API route to fix 404

### DIFF
--- a/new-project/src/app/api/blog/route.ts
+++ b/new-project/src/app/api/blog/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabaseClient';
+
+export async function GET() {
+  const { data, error } = await supabase
+    .from('BlogPosts')
+    .select('titulo_post, imagen_url, fecha_creacion, contenido_post')
+    .order('fecha_creacion', { ascending: false });
+
+  if (error) {
+    return NextResponse.json(
+      { success: false, message: error.message },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json(data ?? []);
+}

--- a/new-project/src/components/BlogPage.tsx
+++ b/new-project/src/components/BlogPage.tsx
@@ -19,6 +19,11 @@ export default function BlogPage() {
       try {
         const apiBase = process.env.NEXT_PUBLIC_API_URL || '';
         const res = await fetch(`${apiBase}/api/blog`);
+
+        if (!res.ok) {
+          throw new Error(`Error al obtener posts: ${res.status}`);
+        }
+
         const data = await res.json();
         setPosts(data);
       } catch (err) {


### PR DESCRIPTION
## Summary
- add `/api/blog` route to provide blog posts from Supabase
- improve blog page fetch error handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca8b5974c8331b180c60d637bcecc