### PR TITLE
Use Redis cache and interaction table for community features

### DIFF
--- a/new-project/src/app/api/blog/route.ts
+++ b/new-project/src/app/api/blog/route.ts
@@ -2,17 +2,19 @@ import { NextResponse } from 'next/server';
 import { supabase } from '@/lib/supabaseClient';
 
 export async function GET() {
-  const { data, error } = await supabase
-    .from('BlogPosts')
-    .select('titulo_post, imagen_url, fecha_creacion, contenido_post')
-    .order('fecha_creacion', { ascending: false });
+  try {
+    const { data, error } = await supabase
+      .from('Posts')
+      .select('titulo_post, imagen_url, fecha_creacion, contenido_post')
+      .eq('id_usuario', 1)
+      .order('id_post', { ascending: true });
 
-  if (error) {
-    return NextResponse.json(
-      { success: false, message: error.message },
-      { status: 500 }
-    );
+    if (error) throw error;
+
+    return NextResponse.json({ success: true, posts: data ?? [] });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Error interno del servidor';
+    console.error('Error fetching blog posts:', message);
+    return NextResponse.json({ success: false, posts: [], message }, { status: 200 });
   }
-
-  return NextResponse.json(data ?? []);
 }

--- a/new-project/src/app/api/darDislike/route.ts
+++ b/new-project/src/app/api/darDislike/route.ts
@@ -4,26 +4,46 @@ import { supabase } from '@/lib/supabaseClient';
 export async function POST(req: Request) {
   const { idPost } = await req.json();
 
-  // The Posts table uses an uppercase name in the database.
-  const { data, error } = await supabase
-    .from('Posts')
-    .select('dislikes')
-    .eq('id_post', idPost)
-    .single();
+  // TODO: obtener el ID de usuario autenticado real
+  const idUsuario = 1;
 
-  if (error) {
-    return NextResponse.json({ success: false, message: error.message }, { status: 500 });
+  try {
+    const { data: existente, error: existenteError } = await supabase
+      .from('Interacciones')
+      .select('id_interaccion, tipo_interaccion')
+      .eq('id_post', idPost)
+      .eq('id_usuario', idUsuario)
+      .maybeSingle();
+
+    if (existenteError) throw existenteError;
+
+    if (existente && existente.tipo_interaccion === 2) {
+      const { error: deleteError } = await supabase
+        .from('Interacciones')
+        .delete()
+        .eq('id_interaccion', existente.id_interaccion);
+      if (deleteError) throw deleteError;
+    } else {
+      if (existente) {
+        const { error: delErr } = await supabase
+          .from('Interacciones')
+          .delete()
+          .eq('id_interaccion', existente.id_interaccion);
+        if (delErr) throw delErr;
+      }
+      const { error: insertError } = await supabase.from('Interacciones').insert({
+        id_post: idPost,
+        id_usuario: idUsuario,
+        tipo_interaccion: 2,
+        fecha_interaccion: new Date().toISOString(),
+      });
+      if (insertError) throw insertError;
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('Error en darDislike:', err);
+    const message = err instanceof Error ? err.message : 'Error interno del servidor';
+    return NextResponse.json({ success: false, message }, { status: 500 });
   }
-
-  const dislikes = (data?.dislikes ?? 0) + 1;
-  const { error: updateError } = await supabase
-    .from('Posts')
-    .update({ dislikes })
-    .eq('id_post', idPost);
-
-  if (updateError) {
-    return NextResponse.json({ success: false, message: updateError.message }, { status: 500 });
-  }
-
-  return NextResponse.json({ success: true });
 }

--- a/new-project/src/app/api/darLike/route.ts
+++ b/new-project/src/app/api/darLike/route.ts
@@ -4,26 +4,46 @@ import { supabase } from '@/lib/supabaseClient';
 export async function POST(req: Request) {
   const { idPost } = await req.json();
 
-  // The Posts table uses an uppercase name in the database.
-  const { data, error } = await supabase
-    .from('Posts')
-    .select('likes')
-    .eq('id_post', idPost)
-    .single();
+  // TODO: obtener el ID de usuario autenticado real
+  const idUsuario = 1;
 
-  if (error) {
-    return NextResponse.json({ success: false, message: error.message }, { status: 500 });
+  try {
+    const { data: existente, error: existenteError } = await supabase
+      .from('Interacciones')
+      .select('id_interaccion, tipo_interaccion')
+      .eq('id_post', idPost)
+      .eq('id_usuario', idUsuario)
+      .maybeSingle();
+
+    if (existenteError) throw existenteError;
+
+    if (existente && existente.tipo_interaccion === 1) {
+      const { error: deleteError } = await supabase
+        .from('Interacciones')
+        .delete()
+        .eq('id_interaccion', existente.id_interaccion);
+      if (deleteError) throw deleteError;
+    } else {
+      if (existente) {
+        const { error: delErr } = await supabase
+          .from('Interacciones')
+          .delete()
+          .eq('id_interaccion', existente.id_interaccion);
+        if (delErr) throw delErr;
+      }
+      const { error: insertError } = await supabase.from('Interacciones').insert({
+        id_post: idPost,
+        id_usuario: idUsuario,
+        tipo_interaccion: 1,
+        fecha_interaccion: new Date().toISOString(),
+      });
+      if (insertError) throw insertError;
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('Error en darLike:', err);
+    const message = err instanceof Error ? err.message : 'Error interno del servidor';
+    return NextResponse.json({ success: false, message }, { status: 500 });
   }
-
-  const likes = (data?.likes ?? 0) + 1;
-  const { error: updateError } = await supabase
-    .from('Posts')
-    .update({ likes })
-    .eq('id_post', idPost);
-
-  if (updateError) {
-    return NextResponse.json({ success: false, message: updateError.message }, { status: 500 });
-  }
-
-  return NextResponse.json({ success: true });
 }

--- a/new-project/src/app/api/obtenerPosts/route.ts
+++ b/new-project/src/app/api/obtenerPosts/route.ts
@@ -3,32 +3,48 @@ import { supabase } from '@/lib/supabaseClient';
 
 export async function GET() {
   try {
-    // The table was created with an uppercase name in PostgreSQL, so we
-    // need to reference it exactly as "Posts" when using Supabase.
-    const { data, error, status } = await supabase
+    const { data, error } = await supabase
       .from('Posts')
-      .select('id_post, contenido_post, fecha_creacion, imagen_url, likes, dislikes')
+      .select('id_post, contenido_post, fecha_creacion, imagen_url, interacciones(id_usuario, tipo_interaccion)')
+      .neq('id_usuario', 1)
       .order('fecha_creacion', { ascending: false });
 
-    if (error) {
-      console.error('Error fetching posts:', error);
-      // Return an empty list but avoid surfacing a 500 to the client so the
-      // page can handle the failure gracefully.
-      return NextResponse.json(
-        { success: false, posts: [], message: error.message },
-        { status: status || 200 }
-      );
+    if (error) throw error;
+
+    // TODO: obtener el ID de usuario autenticado real
+    const idUsuario = 1;
+
+    interface DbInteraccion { id_usuario: number; tipo_interaccion: number }
+    interface DbPost {
+      id_post: number;
+      contenido_post: string;
+      fecha_creacion: string;
+      imagen_url?: string | null;
+      interacciones: DbInteraccion[] | null;
     }
 
-    const posts = (data ?? []).map(post => ({
-      ...post,
-      liked: false,
-      disliked: false,
-    }));
+    const posts = (data as DbPost[] | null)?.map(post => {
+      const interacciones = post.interacciones ?? [];
+      const likes = interacciones.filter(i => i.tipo_interaccion === 1);
+      const dislikes = interacciones.filter(i => i.tipo_interaccion === 2);
+      const liked = likes.some(i => i.id_usuario === idUsuario);
+      const disliked = dislikes.some(i => i.id_usuario === idUsuario);
+
+      return {
+        id_post: post.id_post,
+        contenido_post: post.contenido_post,
+        fecha_creacion: post.fecha_creacion,
+        imagen_url: post.imagen_url,
+        likes: likes.length,
+        dislikes: dislikes.length,
+        liked,
+        disliked,
+      };
+    }) ?? [];
 
     return NextResponse.json({ success: true, posts });
   } catch (err) {
-    console.error('Unexpected error fetching posts:', err);
+    console.error('Error fetching posts:', err);
     const message = err instanceof Error ? err.message : 'Error interno del servidor';
     return NextResponse.json(
       { success: false, posts: [], message },

--- a/new-project/src/components/BlogPage.tsx
+++ b/new-project/src/components/BlogPage.tsx
@@ -25,7 +25,9 @@ export default function BlogPage() {
         }
 
         const data = await res.json();
-        setPosts(data);
+        if (data.success) {
+          setPosts(data.posts);
+        }
       } catch (err) {
         console.error('Error al obtener posts del blog:', err);
       } finally {

--- a/new-project/src/lib/cache.ts
+++ b/new-project/src/lib/cache.ts
@@ -2,55 +2,35 @@ import { Redis } from '@upstash/redis';
 
 const CACHE_THRESHOLD = parseInt(process.env.CACHE_THRESHOLD || '3', 10);
 const CACHE_TTL_SECONDS = 60 * 60 * 24; // 24 horas
-const CACHE_TTL_MS = CACHE_TTL_SECONDS * 1000;
 
-let redis: Redis | null = null;
-try {
-  redis = Redis.fromEnv();
-} catch {
-  redis = null;
-}
-
-const store = new Map<string, { value: unknown; expires: number }>();
-const freqMap = new Map<string, number>();
+// Instancia del cliente de Redis. Se espera que las variables de entorno
+// `UPSTASH_REDIS_REST_URL` y `UPSTASH_REDIS_REST_TOKEN` estén definidas.
+// Si faltan, `Redis.fromEnv()` lanzará un error y las funciones de lectura
+// y escritura capturarán las excepciones.
+const redis = Redis.fromEnv();
 
 export async function readCache(key: string) {
-  if (redis) {
-    const freqKey = `freq:${key}`;
-    try {
-      const freq = await redis.incr(freqKey);
-      if (freq === 1) await redis.expire(freqKey, CACHE_TTL_SECONDS);
-      const cached = await redis.get<unknown>(key);
-      if (cached !== null) {
-        return { data: cached, source: 'cache', freq } as const;
-      }
-      return { data: null, source: 'openfoodfacts', freq } as const;
-    } catch (err) {
-      console.error('Redis read error:', (err as Error).message);
-      return { data: null, source: 'openfoodfacts', freq: 0 } as const;
+  const freqKey = `freq:${key}`;
+  try {
+    const freq = await redis.incr(freqKey);
+    if (freq === 1) await redis.expire(freqKey, CACHE_TTL_SECONDS);
+    const cached = await redis.get<unknown>(key);
+    if (cached !== null) {
+      return { data: cached, source: 'cache', freq } as const;
     }
+    return { data: null, source: 'openfoodfacts', freq } as const;
+  } catch (err) {
+    console.error('Redis read error:', (err as Error).message);
+    return { data: null, source: 'openfoodfacts', freq: 0 } as const;
   }
-
-  const freq = (freqMap.get(key) ?? 0) + 1;
-  freqMap.set(key, freq);
-  const entry = store.get(key);
-  if (entry && entry.expires > Date.now()) {
-    return { data: entry.value, source: 'cache', freq } as const;
-  }
-  return { data: null, source: 'openfoodfacts', freq } as const;
 }
 
 export async function writeCache(key: string, value: unknown, freq: number) {
-  if (redis) {
-    if (freq < CACHE_THRESHOLD) return;
-    try {
-      await redis.set(key, value, { ex: CACHE_TTL_SECONDS });
-    } catch (err) {
-      console.error('Redis write error:', (err as Error).message);
-    }
-    return;
-  }
-
   if (freq < CACHE_THRESHOLD) return;
-  store.set(key, { value, expires: Date.now() + CACHE_TTL_MS });
+  try {
+    await redis.set(key, value, { ex: CACHE_TTL_SECONDS });
+  } catch (err) {
+    console.error('Redis write error:', (err as Error).message);
+  }
 }
+


### PR DESCRIPTION
## Summary
- remove in-memory fallback and rely solely on Upstash Redis for caching
- drive community likes/dislikes via `Interacciones` table and expose per-user state
- serve blog entries from `Posts` for the admin user

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acaa39614083319fe726ee15e47a56