### PR TITLE
fix: ensure prisma client generated before running app

### DIFF
--- a/new-project/package.json
+++ b/new-project/package.json
@@ -3,8 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "prisma generate",
     "dev": "next dev --turbopack",
+    "prebuild": "prisma generate",
     "build": "next build --turbopack",
+    "prestart": "prisma generate",
     "start": "next start",
     "lint": "eslint",
     "postinstall": "prisma generate"


### PR DESCRIPTION
## Summary
- run `prisma generate` before starting, building or developing the Next.js app to avoid missing client errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find the config "next/core-web-vitals")*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68ad0550367483319bf05922f78facf5