### PR TITLE
fix: correct Supabase connection URL for Prisma

### DIFF
--- a/new-project/.env
+++ b/new-project/.env
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_Y29tbXVuYWwtc2lsa3dvcm0tOTYuY2xlcmsuYWNjb3VudHMuZGV2JA
 NEXT_PUBLIC_SUPABASE_URL=https://cuphajddgbzgnomwsupa.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN1cGhhamRkZ2J6Z25vbXdzdXBhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc5NTc0ODgsImV4cCI6MjA2MzUzMzQ4OH0.lF6bmiaX7-qmAGCOCld5xODe92zrh_AMWmVE-xVGyck
-DATABASE_URL="postgresql://user:password@db.supabase.co:5432/postgres"
-DIRECT_URL="postgresql://user:password@db.supabase.co:5432/postgres"
+DATABASE_URL="postgresql://user:password@db.cuphajddgbzgnomwsupa.supabase.co:5432/postgres?sslmode=require"
+DIRECT_URL="postgresql://user:password@db.cuphajddgbzgnomwsupa.supabase.co:5432/postgres?sslmode=require"


### PR DESCRIPTION
## Summary
- use project-specific Supabase host in DATABASE_URL and DIRECT_URL
- require SSL for Prisma connections

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad0b05a8908331a387a3c5850f8584