### PR TITLE
Configure Supabase and Prisma environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,7 @@
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_Y29tbXVuYWwtc2lsa3dvcm0tOTYuY2xlcmsuYWNjb3VudHMuZGV2JA
 NEXT_PUBLIC_SUPABASE_URL=https://cuphajddgbzgnomwsupa.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN1cGhhamRkZ2J6Z25vbXdzdXBhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc5NTc0ODgsImV4cCI6MjA2MzUzMzQ4OH0.lF6bmiaX7-qmAGCOCld5xODe92zrh_AMWmVE-xVGyck
-DATABASE_URL="postgresql://user:password@aws-0-us-east-1.pooler.supabase.com:5432/postgres?sslmode=require&pgbouncer=true&connection_limit=1"
-DIRECT_URL="postgresql://user:password@aws-0-us-east-1.pooler.supabase.com:5432/postgres?sslmode=require&pgbouncer=true"
+DATABASE_URL="postgresql://postgres:postgres@db.cuphajddgbzgnomwsupa.supabase.co:5432/postgres"
+DIRECT_URL="postgresql://postgres:postgres@db.cuphajddgbzgnomwsupa.supabase.co:5432/postgres"
+UPSTASH_REDIS_REST_URL=http://localhost:6379
+UPSTASH_REDIS_REST_TOKEN=localtoken


### PR DESCRIPTION
## Summary
- configure environment variables for Supabase and Prisma, targeting Supabase-hosted Postgres
- add Upstash Redis connection placeholders to avoid runtime warnings

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad0e954314833199fe40b35fc9b773