### PR TITLE
Fix supabase client usage and post typings

### DIFF
--- a/src/app/api/obtenerPosts/route.ts
+++ b/src/app/api/obtenerPosts/route.ts
@@ -12,7 +12,7 @@ interface PostRecord {
   contenido_post: string;
   fecha_creacion: string;
   imagen_url: string | null;
-  usuario: { nombre: string | null } | null;
+  usuario: { nombre: string | null }[] | null;
   interacciones: Interaccion[] | null;
 }
 
@@ -39,7 +39,7 @@ export async function GET() {
         id_post: post.id_post,
         contenido_post: post.contenido_post,
         fecha_creacion: post.fecha_creacion,
-        autor: post.usuario?.nombre ?? 'Usuario',
+        autor: post.usuario?.[0]?.nombre ?? 'Usuario',
         imagen_url: post.imagen_url,
         likes: likes.length,
         dislikes: dislikes.length,

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -1,10 +1,26 @@
-import { createMiddlewareClient } from '@supabase/ssr'
+import { createServerClient } from '@supabase/ssr'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export async function updateSession(request: NextRequest) {
   const response = NextResponse.next()
-  const supabase = createMiddlewareClient({ req: request, res: response })
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(cookies) {
+          cookies.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, options)
+          )
+        },
+      },
+    }
+  )
+
   await supabase.auth.getSession()
   return response
 }


### PR DESCRIPTION
## Summary
- use createServerClient in middleware to handle cookies and session updates
- correct PostRecord typing for usuario field and adjust mapping

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad1568eda48331af485d81cb877afe