### PR TITLE
Fix Supabase table name references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # misc
 .DS_Store
 *.pem
+new-project/
 
 # debug
 npm-debug.log*

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -5,7 +5,7 @@ export async function GET() {
   try {
     const supabase = await createClient();
     const { data: posts, error } = await supabase
-      .from('posts')
+      .from('Posts')
       .select('titulo_post, imagen_url, fecha_creacion, contenido_post')
       .eq('id_usuario', 1)
       .order('id_post', { ascending: true });

--- a/src/app/api/darDislike/route.ts
+++ b/src/app/api/darDislike/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
   try {
     const supabase = await createClient();
     const { data: existente } = await supabase
-      .from('interacciones')
+      .from('Interacciones')
       .select('id_interaccion, tipo_interaccion')
       .eq('id_post', idPost)
       .eq('id_usuario', idUsuario)
@@ -25,17 +25,17 @@ export async function POST(req: Request) {
 
     if (existente?.tipo_interaccion === 2) {
       await supabase
-        .from('interacciones')
+        .from('Interacciones')
         .delete()
         .eq('id_interaccion', existente.id_interaccion);
     } else {
       if (existente) {
         await supabase
-          .from('interacciones')
+          .from('Interacciones')
           .delete()
           .eq('id_interaccion', existente.id_interaccion);
       }
-      await supabase.from('interacciones').insert({
+      await supabase.from('Interacciones').insert({
         id_post: idPost,
         id_usuario: idUsuario,
         tipo_interaccion: 2,

--- a/src/app/api/darLike/route.ts
+++ b/src/app/api/darLike/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
   try {
     const supabase = await createClient();
     const { data: existente } = await supabase
-      .from('interacciones')
+      .from('Interacciones')
       .select('id_interaccion, tipo_interaccion')
       .eq('id_post', idPost)
       .eq('id_usuario', idUsuario)
@@ -25,17 +25,17 @@ export async function POST(req: Request) {
 
     if (existente?.tipo_interaccion === 1) {
       await supabase
-        .from('interacciones')
+        .from('Interacciones')
         .delete()
         .eq('id_interaccion', existente.id_interaccion);
     } else {
       if (existente) {
         await supabase
-          .from('interacciones')
+          .from('Interacciones')
           .delete()
           .eq('id_interaccion', existente.id_interaccion);
       }
-      await supabase.from('interacciones').insert({
+      await supabase.from('Interacciones').insert({
         id_post: idPost,
         id_usuario: idUsuario,
         tipo_interaccion: 1,

--- a/src/app/api/obtenerPosts/route.ts
+++ b/src/app/api/obtenerPosts/route.ts
@@ -20,11 +20,11 @@ export async function GET() {
   try {
     const supabase = await createClient();
     const { data, error } = await supabase
-      .from('posts')
+      .from('Posts')
       .select(
         `id_post, contenido_post, fecha_creacion, imagen_url,
-         usuario:usuarios(nombre),
-         interacciones(id_usuario, tipo_interaccion)`
+         usuario:Usuarios(nombre),
+         interacciones:Interacciones(id_usuario, tipo_interaccion)`
       )
       .neq('id_usuario', 1)
       .order('fecha_creacion', { ascending: false });

--- a/src/app/api/publicarPost/route.ts
+++ b/src/app/api/publicarPost/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
   try {
     const supabase = await createClient();
     const { data: nuevo, error } = await supabase
-      .from('posts')
+      .from('Posts')
       .insert({
         contenido_post: contenidoPost,
         imagen_url: imagenUrl,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,7 +15,7 @@ export async function getAuthedUser() {
 
   const supabase = await createClient();
   const { data: existing, error } = await supabase
-    .from('usuarios')
+    .from('Usuarios')
     .select('*')
     .eq('email', email)
     .maybeSingle();
@@ -23,7 +23,7 @@ export async function getAuthedUser() {
 
   if (!existing) {
     const { data: newUser, error: insertError } = await supabase
-      .from('usuarios')
+      .from('Usuarios')
       .insert({
         nombre: user.firstName || 'Usuario',
         email,


### PR DESCRIPTION
## Summary
- use correct casing for Supabase table names
- ignore local `new-project` directory

## Testing
- `npm run lint` *(fails: ESLint couldn't find config "next/core-web-vitals")*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad18163b648331a99ba17a1ee1894c