### PR TITLE
Use Upstash Redis exclusively for caching

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -3,8 +3,8 @@ import { Redis } from '@upstash/redis';
 const CACHE_THRESHOLD = parseInt(process.env.CACHE_THRESHOLD || '3', 10);
 const CACHE_TTL_SECONDS = 60 * 60 * 24; // 24 horas
 
-// Intentamos conectar a Redis solo si las variables de entorno existen.
-// Si la conexión falla, se usará un mapa en memoria como respaldo.
+// Inicializamos Redis desde las variables de entorno. Si falla la conexión
+// simplemente no se usará caché.
 let redis: Redis | null = null;
 try {
   redis = Redis.fromEnv();
@@ -12,52 +12,32 @@ try {
   console.error('Redis init error:', (err as Error).message);
 }
 
-const memory = new Map<string, { value: unknown; expires: number }>();
-const freqMemory = new Map<string, { value: number; expires: number }>();
-
 export async function readCache(key: string) {
   const freqKey = `freq:${key}`;
 
+  if (!redis) {
+    return { data: null, source: 'openfoodfacts', freq: 1 } as const;
+  }
+
   try {
-    if (redis) {
-      const freq = await redis.incr(freqKey);
-      if (freq === 1) await redis.expire(freqKey, CACHE_TTL_SECONDS);
-      const cached = await redis.get<unknown>(key);
-      if (cached !== null) {
-        return { data: cached, source: 'cache', freq } as const;
-      }
-      return { data: null, source: 'openfoodfacts', freq } as const;
-    }
-
-    // Respaldo en memoria
-    const now = Date.now();
-    let freq = 1;
-    const freqEntry = freqMemory.get(freqKey);
-    if (freqEntry && freqEntry.expires > now) {
-      freq = ++freqEntry.value;
-    }
-    freqMemory.set(freqKey, { value: freq, expires: now + CACHE_TTL_SECONDS * 1000 });
-
-    const cached = memory.get(key);
-    if (cached && cached.expires > now) {
-      return { data: cached.value, source: 'cache', freq } as const;
+    const freq = await redis.incr(freqKey);
+    if (freq === 1) await redis.expire(freqKey, CACHE_TTL_SECONDS);
+    const cached = await redis.get<unknown>(key);
+    if (cached !== null) {
+      return { data: cached, source: 'cache', freq } as const;
     }
     return { data: null, source: 'openfoodfacts', freq } as const;
   } catch (err) {
     console.error('Redis read error:', (err as Error).message);
-    return { data: null, source: 'openfoodfacts', freq: 0 } as const;
+    return { data: null, source: 'openfoodfacts', freq: 1 } as const;
   }
 }
 
 export async function writeCache(key: string, value: unknown, freq: number) {
-  if (freq < CACHE_THRESHOLD) return;
+  if (freq < CACHE_THRESHOLD || !redis) return;
+
   try {
-    if (redis) {
-      await redis.set(key, value, { ex: CACHE_TTL_SECONDS });
-      return;
-    }
-    // Respaldo en memoria
-    memory.set(key, { value, expires: Date.now() + CACHE_TTL_SECONDS * 1000 });
+    await redis.set(key, value, { ex: CACHE_TTL_SECONDS });
   } catch (err) {
     console.error('Redis write error:', (err as Error).message);
   }


### PR DESCRIPTION
## Summary
- remove in-memory cache fallback
- rely solely on Upstash Redis for cache reads/writes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad9d549b9c8331bd1452c91845c178