### PR TITLE
Fix type error in compare page

### DIFF
--- a/src/components/ComparePage.tsx
+++ b/src/components/ComparePage.tsx
@@ -123,7 +123,7 @@ export default function ComparePage() {
     },
   ];
 
-  const getValue = (obj: Record<string, unknown>, path: string[]) =>
+  const getValue = (obj: unknown, path: string[]): unknown =>
     path.reduce<unknown>((acc, key) => {
       if (typeof acc === 'object' && acc !== null && key in acc) {
         return (acc as Record<string, unknown>)[key];
@@ -164,7 +164,7 @@ export default function ComparePage() {
                     const hasData = val != null;
                     return (
                       <td key={i} className={hasData ? '' : 'no-data'}>
-                        {hasData ? val : 'Sin datos'}
+                        {hasData ? (val as React.ReactNode) : 'Sin datos'}
                       </td>
                     );
                   })}


### PR DESCRIPTION
## Summary
- avoid compile error by using an unknown parameter in `getValue`
- cast field values to `React.ReactNode` when rendering

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adaa8012f8833185d107d07221d344