### PR TITLE
fix: use local API for comparison

### DIFF
--- a/src/components/ComparePage.tsx
+++ b/src/components/ComparePage.tsx
@@ -45,12 +45,11 @@ export default function ComparePage() {
       return;
     }
     setLoading(true);
-    const apiBase =
-      process.env.NEXT_PUBLIC_API_URL || 'https://zeta-v2-backend.vercel.app';
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || '';
     Promise.all(
       codes.map((c) =>
         fetch(`${apiBase}/api/product?query=${encodeURIComponent(c)}`)
-          .then((res) => res.json())
+          .then((res) => (res.ok ? res.json() : null))
           .catch(() => null),
       ),
     ).then((data) => {


### PR DESCRIPTION
## Summary
- use in-app API route for product comparison

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adadb7bf0c8331bd0af19e816872ea