### PR TITLE
Exclude contact API from Clerk middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,6 @@ export default clerkMiddleware(async (_auth, req) => {
 });
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|api/contact).*)'],
 };
 


### PR DESCRIPTION
## Summary
- allow unauthenticated contact form submissions by excluding `/api/contact` from Clerk middleware

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adb772bc6c8331bded4f3d6f39e0f6