### PR TITLE
Enforce Clerk middleware and surface missing credentials

### DIFF
--- a/src/utils/supabase/config.ts
+++ b/src/utils/supabase/config.ts
@@ -1,5 +1,4 @@
-
-export function isSupabaseConfigured() {
+export function isSupabaseConfigured(): boolean {
   return Boolean(
     process.env.NEXT_PUBLIC_SUPABASE_URL &&
       process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
@@ -7,21 +6,15 @@ export function isSupabaseConfigured() {
 }
 
 export function getSupabaseConfig() {
-  if (!isSupabaseConfigured()) {
-export function getSupabaseConfig() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
   if (!url || !key) {
-    throw new Error(
-      'Supabase environment variables are not configured. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY.',
-    );
+    const message =
+      'Supabase environment variables are not configured. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY.';
+    console.error(message);
+    throw new Error(message);
   }
-
-  return {
-    url: process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    key: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
-  };
 
   return { url, key };
 }

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -3,35 +3,23 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { getSupabaseConfig } from './config';
 
-let hasLoggedSupabaseWarning = false;
-
 export async function updateSession(request: NextRequest) {
   const response = NextResponse.next();
-  try {
-    const { url, key } = getSupabaseConfig();
-    const supabase = createServerClient(url, key, {
-      cookies: {
-        get(name: string) {
-          return request.cookies.get(name)?.value;
-        },
-        set(name: string, value: string, options: CookieOptions) {
-          response.cookies.set(name, value, options);
-        },
-        remove(name: string, _options: CookieOptions) {
-          void _options;
-          response.cookies.delete(name);
-        },
+  const { url, key } = getSupabaseConfig();
+  const supabase = createServerClient(url, key, {
+    cookies: {
+      get(name: string) {
+        return request.cookies.get(name)?.value;
       },
-    });
-    await supabase.auth.getSession();
-  } catch (error) {
-    if (!hasLoggedSupabaseWarning && process.env.NODE_ENV !== 'production') {
-      console.warn(
-        'Supabase credentials are not configured. Skipping session refresh.',
-        error,
-      );
-      hasLoggedSupabaseWarning = true;
-    }
-  }
+      set(name: string, value: string, options: CookieOptions) {
+        response.cookies.set(name, value, options);
+      },
+      remove(name: string, _options: CookieOptions) {
+        void _options;
+        response.cookies.delete(name);
+      },
+    },
+  });
+  await supabase.auth.getSession();
   return response;
 }


### PR DESCRIPTION
## Summary
- require Clerk credentials before running the middleware and stop falling back to Supabase-only handling
- wrap Clerk middleware execution to log and rethrow failures for clearer debugging
- make Supabase session sync report missing configuration and propagate errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfb54d92f0833180b35cca9a9d2075